### PR TITLE
chore: add serpapi tool and use .env file

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,15 @@ Github-Agent is a test application that leverages [PyGithub](https://github.com/
 <video src="docs/demo.mov" alt="Demo video"></video>
 
 ## 🧪 Features
-- Search repositories by name
-- Get pull requests (PRs) and issues
+- Search repositories by name.
+- Get pull requests (PRs) and issues.
 - Access the body and collaborators of specific PRs or issues.
+- Search the internet to solve issues or search for projects.
 
 ## How to use
 1. `git clone https://github.com/cacosandon/github-agent/tree/main`
 
-2. Fill `OPENAI_API_KEY` and `GITHUB_TOKEN` (optional) in `main.py` with your tokens. Github token is not necessary. Adding your Github token allows you to increase the API limit rate and also give access to your repositories.
+2. Fill `OPENAI_API_KEY`, `GITHUB_TOKEN` (optional) and `SERPAPI_API_KEY` (optional) in a `.env` file with your tokens. Github token is not necessary. Adding your Github token allows you to increase the API limit rate and also give access to your repositories.
 
 3. Create an environment and install dependencies with `poetry shell && poetry install`
 

--- a/main.py
+++ b/main.py
@@ -1,23 +1,40 @@
+import os
+from dotenv import load_dotenv
+
 from langchain.tools import StructuredTool
 from langchain.chat_models import ChatOpenAI
 from langchain.agents import initialize_agent, AgentType
+from langchain.utilities import SerpAPIWrapper
 
 from github_agent.tools.github_tool import GithubTools
 
-OPENAI_API_KEY = "your openai api key here"
-GITHUB_TOKEN = "your github token here"
+load_dotenv()
 
-github_tools = GithubTools(token=GITHUB_TOKEN)
+OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY", "")
+GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN", "")
+SERPAPI_API_KEY = os.environ.get("SERPAPI_API_KEY")
 
+github_functions = GithubTools(token=GITHUB_TOKEN)
 tools = [
-    StructuredTool.from_function(github_tools.search_repositories),
-    StructuredTool.from_function(github_tools.get_repository_pull_requests),
-    StructuredTool.from_function(github_tools.get_repository_pull_request_information),
-    StructuredTool.from_function(github_tools.get_repository_issues),
-    StructuredTool.from_function(github_tools.get_repository_issue_information),
+    StructuredTool.from_function(github_functions.search_repositories),
+    StructuredTool.from_function(github_functions.get_repository_pull_requests),
+    StructuredTool.from_function(github_functions.get_repository_pull_request_information),
+    StructuredTool.from_function(github_functions.get_repository_issues),
+    StructuredTool.from_function(github_functions.get_repository_issue_information),
 ]
 
-llm = ChatOpenAI(openai_api_key=OPENAI_API_KEY, streaming=True, verbose=True, model="gpt-3.5-turbo")
+if SERPAPI_API_KEY:
+    tools += [
+        StructuredTool.from_function(SerpAPIWrapper().run, name="search"),
+    ]
+
+llm = ChatOpenAI(
+    openai_api_key=OPENAI_API_KEY,
+    temperature=0,
+    streaming=True,
+    verbose=True,
+    model="gpt-3.5-turbo",
+)
 
 agent = initialize_agent(
     tools, llm, agent=AgentType.STRUCTURED_CHAT_ZERO_SHOT_REACT_DESCRIPTION, verbose=True

--- a/poetry.lock
+++ b/poetry.lock
@@ -506,6 +506,20 @@ files = [
 ]
 
 [[package]]
+name = "google-search-results"
+version = "2.4.2"
+description = "Scrape and search localized results from Google, Bing, Baidu, Yahoo, Yandex, Ebay, Homedepot, youtube at scale using SerpApi.com"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "google_search_results-2.4.2.tar.gz", hash = "sha256:603a30ecae2af8e600b22635757a6df275dad4b934f975e67878ccd640b78245"},
+]
+
+[package.dependencies]
+requests = "*"
+
+[[package]]
 name = "greenlet"
 version = "2.0.2"
 description = "Lightweight in-process concurrent programming"
@@ -1040,6 +1054,21 @@ docs = ["sphinx (>=1.6.5)", "sphinx-rtd-theme"]
 tests = ["hypothesis (>=3.27.0)", "pytest (>=3.2.1,!=3.3.0)"]
 
 [[package]]
+name = "python-dotenv"
+version = "1.0.0"
+description = "Read key-value pairs from a .env file and set them as environment variables"
+category = "main"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "python-dotenv-1.0.0.tar.gz", hash = "sha256:a8df96034aae6d2d50a4ebe8216326c61c3eb64836776504fcca410e5937a3ba"},
+    {file = "python_dotenv-1.0.0-py3-none-any.whl", hash = "sha256:f5971a9226b701070a4bf2c38c89e5a3f0d64de8debda981d1db98583009122a"},
+]
+
+[package.extras]
+cli = ["click (>=5.0)"]
+
+[[package]]
 name = "pyyaml"
 version = "6.0"
 description = "YAML parser and emitter for Python"
@@ -1447,4 +1476,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "46f304cd31fa3507bc08b960d1049dec3c88be20065f9e39a51c83ae958eafa4"
+content-hash = "347a69c4ac37e22ea14ac413e9a4c78cb6d7fba3733fda646611f12eef0339fb"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,8 @@ python = "^3.11"
 langchain = "^0.0.202"
 openai = "^0.27.8"
 pygithub = "^1.58.2"
+python-dotenv = "^1.0.0"
+google-search-results = "^2.4.2"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
Prefer using `.env` file for api keys and tokens.

Add support for searching over the internet. Useful for searching for projects, querying how to solve an issue, etc.